### PR TITLE
Allow bot set altitude

### DIFF
--- a/pgoapi/rpc_api.py
+++ b/pgoapi/rpc_api.py
@@ -177,7 +177,8 @@ class RpcApi:
         if player_position is not None:
             request.latitude, request.longitude, request.altitude = player_position
 
-        request.altitude = 8  # not as suspicious as 0
+        if request.altitude == 0:
+            request.altitude = 8  # not as suspicious as 0
 
         """ generate sub requests before signature generation """
         request = self._build_sub_requests(request, subrequests)


### PR DESCRIPTION
Instead of using 8 as altitude everytime, we check for user set altitude before defaulting it to 8.0
